### PR TITLE
Added slug regex to Page slug route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -34,7 +34,7 @@ Route::group(['prefix' => 'posts', 'middleware' => ['web']], function () use ($p
  *   (it takes care of this route for us)
  */
 if (!class_exists('\Pvtl\VoyagerPageBlocks\Providers\PageBlocksServiceProvider')) {
-    Route::get('/{slug?}', "$pageController@getPage")->middleware('web');
+    Route::get('/{slug?}', "$pageController@getPage")->middleware('web')->where('slug', '.+');
 }
 
 /**


### PR DESCRIPTION
Presently, you can't add forward slashes to Page slugs meaning URLs like http://mywebsite.com/foo/bar/test will not resolve to a Page bearing slug "foo/bar/test".

By adding a regex to the Page route, a la Symfony (https://symfony.com/doc/current/routing/slash_in_parameter.html), it is possible to route to such Pages.