### PR TITLE
Update ClassEvents.php, bug with $forcedParams

### DIFF
--- a/src/Helpers/ClassEvents.php
+++ b/src/Helpers/ClassEvents.php
@@ -23,6 +23,10 @@ class ClassEvents
 
         $class = resolve($className);
 
-        return $class->$methodName($forcedParams, ...$parameters);
+        if($forcedParams) {
+            array_unshift($parameters, ...$forcedParams);
+        }
+        
+        return $class->$methodName(...$parameters);
     }
 }


### PR DESCRIPTION
The $parameters where always being overwritten by $forcedParams = null
example: 
"Pvtl\VoyagerFrontend\Http\Controllers\PostController::recentBlogPosts(2)" would always return the default 4: 

Only add the forced parameters before the parameters when they are set.